### PR TITLE
git add --all

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@
   </tr>
   
   <tr>
+    <td>git add --all</td>
+    <td>Coloca todos arquivos (novos, modificados e removidos) no index/stage. Adiciona ao staging arquivos desde a raiz do repositório passando por todos os subdiretórios, e aqui está a diferença, não importa se você está na raiz ou no sub-diretório.</td>
+  </tr>
+  
+  <tr>
     <td>git commit -m "Mensagem"</td>
     <td>Realiza o commit com o título.</td>
   </tr>


### PR DESCRIPTION
Coloca todos arquivos (novos, modificados e removidos) no index/stage. Adiciona ao staging arquivos desde a raiz do repositório passando por todos os subdiretórios, e aqui está a diferença, não importa se você está na raiz ou no sub-diretório.